### PR TITLE
swfparser.py is installed as executable script

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,11 +9,11 @@ You can pronounce whatever you like :)
 How to use it
 -------------
 
-You can use ``swfparser.py`` as command line program or as a module.
+You can use ``swfparser`` as command line program.
 
 If you execute directly the usage is::
 
-    swfparser.py [-h] [-t] [-e] filepath
+    swfparser [-h] [-t] [-e] filepath
 
     positional arguments:
       filepath         the SWF file to parse
@@ -23,7 +23,7 @@ If you execute directly the usage is::
       -t, --show-tags  show the first level tags of the file
       -e, --extended   show all objects with full detail and nested
 
-If you want to use it as a module, you can use the ``SWFParser`` class
+If you want to use ``swfparser`` as a module, you can use the ``SWFParser`` class
 directly or the handy ``parsefile`` function::
 
     >>> swf = swfparser.parsefile(<yourSWFfile>)

--- a/bin/swfparser
+++ b/bin/swfparser
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+
+# Copyright 2014 Facundo Batista
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 3, as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranties of
+# MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR
+# PURPOSE.  See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For further info, check  http://github.com/facundobatista/yaswfp
+
+
+from yaswfp.swfparser import parsefile, _coverage
+
+if __name__ == '__main__':
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description='Parse a SWF file and show all its internals')
+    parser.add_argument('filepath', help='the SWF file to parse')
+    parser.add_argument('-t', '--show-tags', action='store_true',
+                        help='show the first level tags of the file')
+    parser.add_argument('-e', '--extended', action='store_true',
+                        help='show all objects with full detail and nested')
+    parser.add_argument('-c', '--coverage', action='store_true',
+                        help='indicate a percentage of coverage of given file')
+    args = parser.parse_args()
+
+    swf = parsefile(args.filepath)
+    print(swf.header)
+    print("Tags count:", len(swf.tags))
+
+    if args.coverage:
+        _coverage(swf.tags)
+
+    if args.show_tags or args.extended:
+        f = repr if args.extended else str
+        for tag in swf.tags:
+            print(f(tag))

--- a/setup.py
+++ b/setup.py
@@ -45,5 +45,5 @@ setup(
     long_description=README,
     url='http://github.com/facundobatista/yaswfp',
     packages=['yaswfp'],
-    scripts=[os.path.join('yaswfp', 'swfparser.py')]
+    scripts=[os.path.join('bin', 'swfparser')]
 )

--- a/yaswfp/swfparser.py
+++ b/yaswfp/swfparser.py
@@ -33,16 +33,7 @@ is found.
 import collections
 import io
 import zlib
-try:
-    from helpers import (
-        BitConsumer,
-        unpack_si16,
-        unpack_ui16,
-        unpack_ui32,
-        unpack_ui8,
-    )
-except ImportError:
-    from yaswfp.helpers import(
+from .helpers import (
         BitConsumer,
         unpack_si16,
         unpack_ui16,
@@ -1247,29 +1238,3 @@ def parsefile(filename):
     with open(filename, 'rb') as fh:
         return SWFParser(fh)
 
-
-if __name__ == '__main__':
-    import argparse
-
-    parser = argparse.ArgumentParser(
-        description='Parse a SWF file and show all its internals')
-    parser.add_argument('filepath', help='the SWF file to parse')
-    parser.add_argument('-t', '--show-tags', action='store_true',
-                        help='show the first level tags of the file')
-    parser.add_argument('-e', '--extended', action='store_true',
-                        help='show all objects with full detail and nested')
-    parser.add_argument('-c', '--coverage', action='store_true',
-                        help='indicate a percentage of coverage of given file')
-    args = parser.parse_args()
-
-    swf = parsefile(args.filepath)
-    print(swf.header)
-    print("Tags count:", len(swf.tags))
-
-    if args.coverage:
-        _coverage(swf.tags)
-
-    if args.show_tags or args.extended:
-        f = repr if args.extended else str
-        for tag in swf.tags:
-            print(f(tag))


### PR DESCRIPTION
the README said  `swfparser.py` can be used as a command line program (which is great), but it isn't installed as one.  this patch fix that. 
